### PR TITLE
Fix fprintf-warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microcode/canary",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Native watchdog",
   "main": "index.js",
   "author": "jesper@microcode.se",

--- a/src/watchdog.cpp
+++ b/src/watchdog.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <memory.h>
+#include <inttypes.h>
 
 #define EXIT_CODE (87)
 
@@ -80,13 +81,13 @@ private:
                     {
                         if (m_print)
                         {
-                            fprintf(stderr, "FATAL: canary - watchdog timeout detected (no ping after %llums), exiting application.\n", m_timeout / 1000000);
+                            fprintf(stderr, "FATAL: canary - watchdog timeout detected (no ping after %" PRIu64 "ms), exiting application.\n", m_timeout / 1000000);
                         }
                         exit(EXIT_CODE);
                     }
                     else if (m_print)
                     {
-                        fprintf(stderr, "canary - watchdog timeout detected (no ping after %llums)\n", m_timeout / 1000000);
+                        fprintf(stderr, "canary - watchdog timeout detected (no ping after %" PRIu64 "ms)\n", m_timeout / 1000000);
                     }
 
                 }

--- a/src/watchdog.cpp
+++ b/src/watchdog.cpp
@@ -80,13 +80,13 @@ private:
                     {
                         if (m_print)
                         {
-                            fprintf(stderr, "FATAL: canary - watchdog timeout detected (no ping after %lums), exiting application.\n", m_timeout / 1000000);
+                            fprintf(stderr, "FATAL: canary - watchdog timeout detected (no ping after %llums), exiting application.\n", m_timeout / 1000000);
                         }
                         exit(EXIT_CODE);
                     }
                     else if (m_print)
                     {
-                        fprintf(stderr, "canary - watchdog timeout detected (no ping after %lums)\n", m_timeout / 1000000);
+                        fprintf(stderr, "canary - watchdog timeout detected (no ping after %llums)\n", m_timeout / 1000000);
                     }
 
                 }


### PR DESCRIPTION
Fix fprintf-warnings occuring on different platforms by using appropriate platform-agnostic types.